### PR TITLE
Use amazon.image

### DIFF
--- a/packer/artifacts/creating-amis.html.md
+++ b/packer/artifacts/creating-amis.html.md
@@ -22,7 +22,7 @@ This spins up an AWS instance in your account and provisions it with
 1. Packer stops the instance and stores the result as an AMI in AWS
 under your account. This then returns an ID (the artifact) that it passes to the Atlas post-processor
 1. The Atlas post-processor creates and uploads the new artifact version with the
-ID in Atlas of the type `amazon.ami` for use later
+ID in Atlas of the type `amazon.image` for use later
 
 ### Example
 
@@ -49,7 +49,7 @@ Below is a complete example Packer template that starts an AWS instance.
         {
           "type": "atlas",
           "artifact": "acmeinc/web-server",
-          "artifact_type": "amazon.ami"
+          "artifact_type": "amazon.image"
         }
       ]
     }

--- a/packer/artifacts/index.html.erb
+++ b/packer/artifacts/index.html.erb
@@ -7,10 +7,23 @@ Packer creates and uploads artifacts to Atlas. This is done
 with the [Atlas post-processor](https://packer.io/docs/post-processors/atlas.html).
 
 Artifacts can then be used in Atlas to deploy services or access
-via Vagrant. Artifacts are generic, but can be of varying types
-like `amazon.image` or `vagrant.box`. These types define different
-behavior within Atlas. See the Packer [`artifact_type`](https://packer.io/docs/post-processors/atlas.html#artifact_type)
-docs for more information.
+via Vagrant. Artifacts are generic, but can be of varying types.
+These types define different behavior within Atlas.
+
+For uploading artifacts to Atlas, `artifact_type` can be set to any
+unique identifier, however, the following are recommended for consistency.
+
+- `amazon.image`
+- `digitalocean.image`
+- `docker.image`
+- `googlecompute.image`
+- `openstack.image`
+- `parallels.image`
+- `qemu.image`
+- `virtualbox.image`
+- `vmware.image`
+- `custom.image`
+- `vagrant.box`
 
 Packer can create artifacts both while running in Atlas and out of Atlas'
 network. This is possible due to the post-processors use of the public

--- a/packer/artifacts/index.html.erb
+++ b/packer/artifacts/index.html.erb
@@ -8,8 +8,9 @@ with the [Atlas post-processor](https://packer.io/docs/post-processors/atlas.htm
 
 Artifacts can then be used in Atlas to deploy services or access
 via Vagrant. Artifacts are generic, but can be of varying types
-like `amazon.ami` or `vagrant.box`. These types define different
-behavior within Atlas.
+like `amazon.image` or `vagrant.box`. These types define different
+behavior within Atlas. See the Packer [`artifact_type`](https://packer.io/docs/post-processors/atlas.html#artifact_type)
+docs for more information.
 
 Packer can create artifacts both while running in Atlas and out of Atlas'
 network. This is possible due to the post-processors use of the public

--- a/packer/artifacts/index.html.erb
+++ b/packer/artifacts/index.html.erb
@@ -23,6 +23,7 @@ unique identifier, however, the following are recommended for consistency.
 - `virtualbox.image`
 - `vmware.image`
 - `custom.image`
+- `application.archive`
 - `vagrant.box`
 
 Packer can create artifacts when running in Atlas or locally.

--- a/packer/artifacts/index.html.erb
+++ b/packer/artifacts/index.html.erb
@@ -25,8 +25,8 @@ unique identifier, however, the following are recommended for consistency.
 - `custom.image`
 - `vagrant.box`
 
-Packer can create artifacts both while running in Atlas and out of Atlas'
-network. This is possible due to the post-processors use of the public
+Packer can create artifacts when running in Atlas or locally.
+This is possible due to the post-processors use of the public
 artifact API to store the artifacts.
 
 You can read more about artifacts and their use in the [Terraform section](/help/terraform/features)

--- a/packer/builds/build-environment.html.md
+++ b/packer/builds/build-environment.html.md
@@ -103,6 +103,7 @@ The keys for the following artifact types will be injected:
 
 - `aws.ami`: `ATLAS_BASE_ARTIFACT_AWS_AMI_ID`
 - `amazon.ami`: `ATLAS_BASE_ARTIFACT_AMAZON_AMI_ID`
+- `amazon.image`: `ATLAS_BASE_ARTIFACT_AMAZON_IMAGE_ID`
 
 You can then reference this artifact in your Packer template, like this
 AWS example:
@@ -126,7 +127,7 @@ AWS example:
 
 ## Notes on Security
 
-Packer environment variables in Atlas are encrypted using [Vault](https://vaultproject.io) 
-and closely guarded and audited. If you have questions or concerns 
-about the safety of your configuration, please contact our security team 
+Packer environment variables in Atlas are encrypted using [Vault](https://vaultproject.io)
+and closely guarded and audited. If you have questions or concerns
+about the safety of your configuration, please contact our security team
 at [security@hashicorp.com](mailto:security@hashicorp.com).

--- a/terraform/artifacts/artifact-provider.html.md
+++ b/terraform/artifacts/artifact-provider.html.md
@@ -17,7 +17,7 @@ is defined and references an AMI ID stored in Atlas.
 
     resource "atlas_artifact" "web-worker" {
         name = "acmeinc/web-worker"
-        type = "amazon.ami"
+        type = "amazon.image"
         version = "latest"
     }
 

--- a/terraform/artifacts/index.html.erb
+++ b/terraform/artifacts/index.html.erb
@@ -8,7 +8,8 @@ artifacts are [stored with Packer](/help/packer/artifacts).
 
 Artifacts can be used in Atlas to deploy and manage images
 of configuration. Artifacts are generic, but can be of varying types
-like `amazon.ami`.
+like `amazon.image` or `vagrant.box`. See the Packer [`artifact_type`](https://packer.io/docs/post-processors/atlas.html#artifact_type)
+docs for more information.
 
 Packer can create artifacts both while running in Atlas and out of Atlas'
 network. This is possible due to the post-processors use of the public

--- a/terraform/artifacts/index.html.erb
+++ b/terraform/artifacts/index.html.erb
@@ -8,7 +8,7 @@ artifacts are [stored with Packer](/help/packer/artifacts).
 
 Artifacts can be used in Atlas to deploy and manage images
 of configuration. Artifacts are generic, but can be of varying types
-like `amazon.image` or `vagrant.box`. See the Packer [`artifact_type`](https://packer.io/docs/post-processors/atlas.html#artifact_type)
+like `amazon.image`. See the Packer [`artifact_type`](https://packer.io/docs/post-processors/atlas.html#artifact_type)
 docs for more information.
 
 Packer can create artifacts both while running in Atlas and out of Atlas'

--- a/terraform/artifacts/managing-versions.html.md
+++ b/terraform/artifacts/managing-versions.html.md
@@ -25,8 +25,8 @@ The following output is from `terraform show`.
       metadata_full.# = 1
       metadata_full.region-us-east-1 = ami-3a0a1d52
       name = acmeinc/web-worker
-      slug = acmeinc/web-worker/amazon.ami/7
-      type = amazon.ami
+      slug = acmeinc/web-worker/amazon.image/7
+      type = amazon.image
 
 In this case, the version is 7 and can be found in the persisted slug
 attribute.
@@ -38,7 +38,7 @@ deploy.
 
     resource "atlas_artifact" "web-worker" {
         name = "acmeinc/web-worker"
-        type = "amazon.ami"
+        type = "amazon.image"
         version = 7
     }
 
@@ -51,7 +51,7 @@ possible if Atlas was used to build the artifact with Packer.
 
     resource "atlas_artifact" "web-worker" {
         name = "acmeinc/web-worker"
-        type = "amazon.ami"
+        type = "amazon.image"
         build = 5
     }
 


### PR DESCRIPTION
For consistency, we should use amazon.image. cc @KFishner

Need to wait for https://github.com/mitchellh/packer/pull/2712 and https://github.com/hashicorp/terraform/pull/3195 to be merged, then merge https://github.com/hashicorp/atlas/pull/1498 with this.