### PR TITLE
Add docs for storing keys & certs

### DIFF
--- a/terraform/runs/variables-and-configuration.html.md
+++ b/terraform/runs/variables-and-configuration.html.md
@@ -68,7 +68,7 @@ resource was created outside of GitHub (like using `terraform push`).
 
 Atlas has the ability store multi-line files as variables. The recommended way to manage your secret/sensitive multi-line files (SSL keys, certificates, etc.) is to add them as [Terraform Variables](#terraform-variables) in Atlas.
 
-Just like secret strings, it is recommended that you never check-in these multi-line secret files to version control. Best practice is setting a blank [variable in Terraform](https://www.terraform.io/docs/configuration/variables.html) that resources utilizing the file will reference, `terraform push` to Atlas, navigate to the "Variables" section of your Atlas Environment, paste the contents of that file into the variable and save.
+Just like secret strings, it is recommended that you never check-in these multi-line secret files to version control. Best practice is setting a blank [variable in Terraform](https://www.terraform.io/docs/configuration/variables.html) that resources utilizing the file will reference, `terraform push` to Atlas, navigate to the "Variables" section of your Atlas Environment, paste the contents of that file into the variable and save. See example of setting variables below.
 
 Now, any resource that consumes that variable will have access to the file without having to check it in to version control. If you want to run Terraform locally, that file will still need to be passed in as a variable. View the [Terraform Variable Documentation](https://www.terraform.io/docs/configuration/variables.html) for different ways to accomplish this.
 
@@ -77,6 +77,13 @@ A few things to note...
 - [Environment Variables](#environment-variables) do not support multi-line files
 - The `.tfvars` file does not support multi-line files
 - You can still use `.tfvars` to define your blank variable, however, you will not be able to actually set the variable in `.tfvars` with the multi-line file contents like you would a variable in a `.tf` file
+
+```
+variable "certificate_body" {}
+variable "certificate_key" {}
+variable "private_key" {}
+variable "public_key" {}
+```
 
 - - -
 

--- a/terraform/runs/variables-and-configuration.html.md
+++ b/terraform/runs/variables-and-configuration.html.md
@@ -64,9 +64,9 @@ For any of the `GITHUB_` attributes, the value of the environment variable will
 be the empty string (`""`) if the resource is not connected to GitHub or if the
 resource was created outside of GitHub (like using `terraform push`).
 
-## Managing Multi-Line Secret Files
+## Managing Secret Multi-Line Files
 
-Atlas has the ability store multi-line files as variables. The recommended way to manage your multi-line secret files (SSL keys, certificates, etc.) is to add them as [Terraform Variables](#terraform-variables) in Atlas.
+Atlas has the ability store multi-line files as variables. The recommended way to manage your secret/sensitive multi-line files (SSL keys, certificates, etc.) is to add them as [Terraform Variables](#terraform-variables) in Atlas.
 
 Just like secret strings, it is recommended that you never check-in these multi-line secret files to version control. Best practice is setting a blank [variable in Terraform](https://www.terraform.io/docs/configuration/variables.html) that resources utilizing the file will reference, `terraform push` to Atlas, navigate to the "Variables" section of your Atlas Environment, paste the contents of that file into the variable and save.
 

--- a/terraform/runs/variables-and-configuration.html.md
+++ b/terraform/runs/variables-and-configuration.html.md
@@ -64,6 +64,14 @@ For any of the `GITHUB_` attributes, the value of the environment variable will
 be the empty string (`""`) if the resource is not connected to GitHub or if the
 resource was created outside of GitHub (like using `terraform push`).
 
+## Keys & Certs
+
+The recommended way to manage your keys and certs is to add them as [Terraform Variables](#terraform-variables) in Atlas. View the [Terraform Variable Documentation](https://www.terraform.io/docs/configuration/variables.html) to determine how you want to pass these variables.
+
+It is recommended that you never check-in these keys/certs to version control. So, best practice would be setting a blank variable in a `variables.tf` or `terraform.tfvars` file that resources utilizing the key/cert will use, `terraform push` to Atlas, navigate to the "Variables" section of your Atlas Environment, paste your key/cert in and save.
+
+Now, any resource that consumes that variable will have the correct key/cert in Atlas. If you want to run Terraform locally, that variable will still need to be passed in with the correct key/cert.
+
 - - -
 
 ## Notes on Security

--- a/terraform/runs/variables-and-configuration.html.md
+++ b/terraform/runs/variables-and-configuration.html.md
@@ -64,13 +64,19 @@ For any of the `GITHUB_` attributes, the value of the environment variable will
 be the empty string (`""`) if the resource is not connected to GitHub or if the
 resource was created outside of GitHub (like using `terraform push`).
 
-## Keys & Certs
+## Managing Multi-Line Secret Files
 
-The recommended way to manage your keys and certs is to add them as [Terraform Variables](#terraform-variables) in Atlas. View the [Terraform Variable Documentation](https://www.terraform.io/docs/configuration/variables.html) to determine how you want to pass these variables.
+Atlas has the ability store multi-line files as variables. The recommended way to manage your multi-line secret files (SSL keys, certificates, etc.) is to add them as [Terraform Variables](#terraform-variables) in Atlas.
 
-It is recommended that you never check-in these keys/certs to version control. So, best practice would be setting a blank variable in a `variables.tf` or `terraform.tfvars` file that resources utilizing the key/cert will use, `terraform push` to Atlas, navigate to the "Variables" section of your Atlas Environment, paste your key/cert in and save.
+Just like secret strings, it is recommended that you never check-in these multi-line secret files to version control. Best practice is setting a blank [variable in Terraform](https://www.terraform.io/docs/configuration/variables.html) that resources utilizing the file will reference, `terraform push` to Atlas, navigate to the "Variables" section of your Atlas Environment, paste the contents of that file into the variable and save.
 
-Now, any resource that consumes that variable will have the correct key/cert in Atlas. If you want to run Terraform locally, that variable will still need to be passed in with the correct key/cert.
+Now, any resource that consumes that variable will have access to the file without having to check it in to version control. If you want to run Terraform locally, that file will still need to be passed in as a variable. View the [Terraform Variable Documentation](https://www.terraform.io/docs/configuration/variables.html) for different ways to accomplish this.
+
+A few things to note...
+
+- [Environment Variables](#environment-variables) do not support multi-line files
+- The `.tfvars` file does not support multi-line files
+- You can still use `.tfvars` to define your blank variable, however, you will not be able to actually set the variable in `.tfvars` with the multi-line file contents like you would a variable in a `.tf` file
 
 - - -
 


### PR DESCRIPTION
@catsby these docs depend on all Terraform resources being able to take a string as will as a file path for keys and certs. So whenever that goes in we can merge this.

@KFishner @pearkes lmk what you think of the docs.