### PR TITLE
Add docs for customer Terraform Plugins

### DIFF
--- a/terraform/runs/starting.html.md
+++ b/terraform/runs/starting.html.md
@@ -81,3 +81,13 @@ You can enable this feature on a per-environment basis from the
 Combined with
 [Terraform auto apply](/help/terraform/runs/automatic-applies), you can
 continuously deliver infrastructure using Terraform and Atlas.
+
+## Terraform Plugins
+
+If you are using a custom [Terraform Plugin](https://www.terraform.io/docs/plugins/index.html)
+binary for a provider or provisioner that's not currently supported,
+you can still use this in Atlas.
+
+All you need to do is include a Linux AMD64 binary for the plugin
+in the directory in which you run Terraform commands from and Atlas
+will pick it up and use it.

--- a/terraform/runs/starting.html.md
+++ b/terraform/runs/starting.html.md
@@ -85,9 +85,9 @@ continuously deliver infrastructure using Terraform and Atlas.
 ## Terraform Plugins
 
 If you are using a custom [Terraform Plugin](https://www.terraform.io/docs/plugins/index.html)
-binary for a provider or provisioner that's not currently supported,
-you can still use this in Atlas.
+binary for a provider or provisioner that's not currently in a released
+version of Terraform, you can still use this in Atlas.
 
-All you need to do is include a Linux AMD64 binary for the plugin
-in the directory in which you run Terraform commands from and Atlas
-will pick it up and use it.
+All you need to do is include a Linux AMD64 binary for the plugin in the
+directory in which Terraform commands are run from; Atlas will then use
+the plugin the next time you `terraform push` or ingress from GitHub.


### PR DESCRIPTION
Atlas supports custom Terraform plugins but it's not documented. Verified this works.