### PR TITLE
Change atlas_artifact 'version' key to 'build'

### DIFF
--- a/terraform/artifacts/artifact-provider.html.md
+++ b/terraform/artifacts/artifact-provider.html.md
@@ -18,7 +18,7 @@ is defined and references an AMI ID stored in Atlas.
     resource "atlas_artifact" "web-worker" {
       name = "acmeinc/web-worker"
       type = "amazon.image"
-      version = "latest"
+      build = "latest"
     }
 
     resource "aws_instance" "worker-machine" {


### PR DESCRIPTION
I got stuck for a few hours where atlas was telling me to use 'version' in the example once I inspected my artifact. From looking at terraform docs this should be 'build'.